### PR TITLE
feat(api): adiciona CRUD completo de tarefas com testes e seeders

### DIFF
--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -1,0 +1,55 @@
+<?php
+namespace App\Http\Controllers;
+
+use App\Models\Task;
+use Illuminate\Http\Request;
+use App\Services\TaskService;
+use Illuminate\Http\JsonResponse;
+
+class TaskController extends Controller
+{
+    public function __construct(protected TaskService $service) {}
+
+    public function index(): JsonResponse
+    {
+        return response()->json($this->service->all());
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $data = $request->validate([
+            'nome' => 'required|string|max:255',
+            'descricao' => 'nullable|string',
+            'data_limite' => 'nullable|date',
+        ]);
+
+        return response()->json($this->service->create($data), 201);
+    }
+
+    public function show(Task $task): JsonResponse
+    {
+        return response()->json($this->service->find($task->id));
+    }
+
+    public function update(Request $request, Task $task): JsonResponse
+    {
+        $data = $request->validate([
+            'nome' => 'required|string|max:255',
+            'descricao' => 'nullable|string',
+            'data_limite' => 'nullable|date',
+        ]);
+
+        return response()->json($this->service->update($task, $data));
+    }
+
+    public function destroy(Task $task): JsonResponse
+    {
+        $this->service->delete($task);
+        return response()->json(['message' => 'Tarefa excluída.']);
+    }
+
+    public function toggle(Task $task): JsonResponse
+    {
+        return response()->json($this->service->toggle($task));
+    }
+}

--- a/app/Jobs/DeleteCompletedTask.php
+++ b/app/Jobs/DeleteCompletedTask.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Task;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Queue\InteractsWithQueue;
+
+class DeleteCompletedTask implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(public Task $task) {}
+
+    public function handle(): void
+    {
+        // Apenas exclui se ainda estiver finalizada
+        if ($this->task->fresh()->finalizado) {
+            $this->task->delete();
+        }
+    }
+}

--- a/app/Models/Task.php
+++ b/app/Models/Task.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Task extends Model
+{
+    use HasFactory; // para seeder
+    use SoftDeletes;
+
+    protected $fillable = ['nome', 'descricao', 'finalizado', 'data_limite'];
+
+    protected $casts = [
+        'finalizado' => 'boolean',
+        'data_limite' => 'datetime',
+    ];
+}

--- a/app/Services/TaskService.php
+++ b/app/Services/TaskService.php
@@ -1,0 +1,63 @@
+<?php
+namespace App\Services;
+
+use App\Models\Task;
+use App\Jobs\DeleteCompletedTask;
+use Illuminate\Support\Facades\Cache;
+
+class TaskService
+{
+    protected const CACHE_TAG = 'tasks';
+
+    public function all()
+    {
+        return Cache::tags([self::CACHE_TAG])->remember('tasks.all', 60, function () {
+            return Task::whereNull('deleted_at')->latest()->get();
+        });
+    }
+
+    public function find(int $id): Task
+    {
+        return Cache::tags([self::CACHE_TAG])->remember("tasks.{$id}", 60, function () use ($id) {
+            return Task::findOrFail($id);
+        });
+    }
+
+    public function create(array $data): Task
+    {
+        $task = Task::create($data);
+        $this->invalidateCache();
+        return $task;
+    }
+
+    public function update(Task $task, array $data): Task
+    {
+        $task->update($data);
+        $this->invalidateCache($task->id);
+        return $task;
+    }
+
+    public function delete(Task $task): void
+    {
+        $task->delete();
+        $this->invalidateCache($task->id);
+    }
+
+    public function toggle(Task $task): Task
+    {
+        $task->finalizado = !$task->finalizado;
+        $task->save();
+
+        if ($task->finalizado) {
+            DeleteCompletedTask::dispatch($task)->delay(now()->addMinutes(10));
+        }
+
+        $this->invalidateCache($task->id);
+        return $task;
+    }
+
+    protected function invalidateCache(int $taskId = null): void
+    {
+        Cache::tags([self::CACHE_TAG])->flush();
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,9 @@
         }
     },
     "scripts": {
+
+        "test": "php artisan test",
+        "seed": "php artisan migrate:fresh --seed",
         "post-autoload-dump": [
             "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
             "@php artisan package:discover --ansi"

--- a/database/factories/TaskFactory.php
+++ b/database/factories/TaskFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+
+namespace Database\Factories;
+
+use App\Models\Task;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class TaskFactory extends Factory
+{
+    protected $model = Task::class;
+
+    public function definition(): array
+    {
+        return [
+            'nome' => $this->faker->sentence(4),
+            'descricao' => $this->faker->paragraph,
+            'finalizado' => $this->faker->boolean(30),
+            'data_limite' => $this->faker->optional()->dateTimeBetween('+1 day', '+1 month'),
+        ];
+    }
+}
+

--- a/database/migrations/2025_06_27_173911_create_tasks_table.php
+++ b/database/migrations/2025_06_27_173911_create_tasks_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void {
+        Schema::create('tasks', function (Blueprint $table) {
+            $table->id();
+            $table->string('nome');
+            $table->text('descricao')->nullable();
+            $table->boolean('finalizado')->default(false);
+            $table->dateTime('data_limite')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->index('finalizado');
+            $table->index('deleted_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('tasks');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -13,7 +13,7 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
+        $this->call(TaskSeeder::class);
 
         User::factory()->create([
             'name' => 'Test User',

--- a/database/seeders/TaskSeeder.php
+++ b/database/seeders/TaskSeeder.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Task;
+
+class TaskSeeder extends Seeder
+{
+    public function run(): void
+    {
+        Task::factory()->count(10)->create();
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,7 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\TaskController;
+
+Route::apiResource('tasks', TaskController::class);
+Route::patch('tasks/{task}/toggle', [TaskController::class, 'toggle']);

--- a/tests/Feature/TaskApiTest.php
+++ b/tests/Feature/TaskApiTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use App\Models\Task;
+
+class TaskApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_can_list_tasks()
+    {
+        Task::factory()->count(3)->create();
+
+        $response = $this->getJson('/api/tasks');
+
+        $response->assertOk()
+                 ->assertJsonCount(3);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_can_create_a_task()
+    {
+        $data = [
+            'nome' => 'Nova tarefa',
+            'descricao' => 'Descrição simples',
+            'data_limite' => now()->addDays(5)->toDateTimeString(),
+        ];
+
+        $response = $this->postJson('/api/tasks', $data);
+
+        $response->assertCreated()
+                 ->assertJsonFragment(['nome' => 'Nova tarefa']);
+
+        $this->assertDatabaseHas('tasks', ['nome' => 'Nova tarefa']);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_can_show_a_task()
+    {
+        $task = Task::factory()->create();
+
+        $response = $this->getJson("/api/tasks/{$task->id}");
+
+        $response->assertOk()
+                 ->assertJsonFragment(['nome' => $task->nome]);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_can_update_a_task()
+    {
+        $task = Task::factory()->create();
+
+        $data = ['nome' => 'Atualizado'];
+
+        $response = $this->putJson("/api/tasks/{$task->id}", $data + [
+            'descricao' => $task->descricao,
+            'data_limite' => optional($task->data_limite)->toDateTimeString(),
+        ]);
+
+        $response->assertOk()
+                 ->assertJsonFragment(['nome' => 'Atualizado']);
+
+        $this->assertDatabaseHas('tasks', ['id' => $task->id, 'nome' => 'Atualizado']);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_can_toggle_a_task()
+    {
+        $task = Task::factory()->create(['finalizado' => false]);
+
+        $response = $this->patchJson("/api/tasks/{$task->id}/toggle");
+
+        $response->assertOk()
+                 ->assertJsonFragment(['finalizado' => true]);
+
+        $this->assertDatabaseHas('tasks', ['id' => $task->id, 'finalizado' => true]);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_can_delete_a_task()
+    {
+        $task = Task::factory()->create();
+
+        $response = $this->deleteJson("/api/tasks/{$task->id}");
+
+        $response->assertOk()
+                 ->assertJson(['message' => 'Tarefa excluída.']);
+
+        $this->assertSoftDeleted('tasks', ['id' => $task->id]);
+    }
+}


### PR DESCRIPTION
feat: implementa backend completo da API de tarefas (To-Do List) - Detalhes 

- Cria model `Task` com SoftDeletes e campos: nome, descricao, finalizado, data_limite
- Cria migration de tasks com índices e suporte a soft deletes
- Implementa controller `TaskController` com endpoints RESTful:
  - index(): listagem de tarefas
  - store(): criação com validação
  - show(): visualização de tarefa específica
  - update(): edição de tarefa
  - destroy(): exclusão lógica (soft delete)
  - toggle(): alternar finalizado/não finalizado
- Registra rotas da API (`/api/tasks`, `/api/tasks/{id}/toggle`)
- Adiciona `TaskFactory` para geração de dados falsos
- Cria `TaskSeeder` para popular banco com dados de exemplo
- Adiciona testes de API (Feature Test `TaskApiTest`) com:
  - Listagem
  - Criação
  - Visualização
  - Atualização
  - Alternância de status
  - Exclusão
- Corrige warnings do PHPUnit atualizando para atributos #[Test]
- Registra corretamente rotas em `bootstrap/app.php` com `withRouting()`
